### PR TITLE
Allow customizing of separator for sequential ranks

### DIFF
--- a/src/SequentialRank.php
+++ b/src/SequentialRank.php
@@ -11,10 +11,10 @@ class SequentialRank
     public function __construct(array $array)
     {
         if (count($array) > 1) {
-			$this->array[] = $array;
-		} else {
-			$this->array = $array;
-		}
+            $this->array[] = $array;
+        } else {
+            $this->array = $array;
+        }
     }
 
     /**
@@ -58,9 +58,9 @@ class SequentialRank
     private function sort(): void
     {
         // Don't bother sorting with a single element
-		if (count($this->array) <= 1) {
-			return;
-		}
+        if (count($this->array) <= 1) {
+            return;
+        }
 
         usort($this->array, function (array $a, array $b) {
             return strnatcmp(

--- a/src/SequentialRank.php
+++ b/src/SequentialRank.php
@@ -71,9 +71,9 @@ class SequentialRank
     }
 
     /**
-     * Return array with Sequential Ranks.
+     * Convert sorted array to Sequential Rank.
      */
-    public function get(): array
+    public function get(string $separator = '-'): array
     {
         $new_array = [];
 
@@ -84,7 +84,7 @@ class SequentialRank
                 $new_array_bit[] = $item;
             }
 
-            $new_array[] = implode('-', $new_array_bit);
+            $new_array[] = implode($separator, $new_array_bit);
         }
 
         return $new_array;


### PR DESCRIPTION
## What does this pull request do?

This PR allows developers to choose the separator used for building sequential ranks. The default separator is still `-`. Also updated the phpdoc for a better description what the `get()` method exactly does.

## Why is this pull request needed?

Developers can choose their preferred separator character and optionally use the `-` character for ranking sequences. It can also shorten the sequential rank string by using `''` as a separator.
